### PR TITLE
Updating CI to publish the extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,12 @@
-name: Tests
+name: Build and Publish
 
 on:
-  pull_request:
-    branches: [main]
   push:
     branches: [main]
 
 jobs:
-  test:
+  publish:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
 
@@ -22,12 +19,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install VS Code
-        run: |
-          curl -L "https://update.code.visualstudio.com/latest/linux-x64/stable" -o vscode.tar.gz
-          tar -xf vscode.tar.gz
+      - name: Build extension
+        run: npm run build
 
-      - name: Run tests
-        run: xvfb-run -a npm test
+      - name: Publish to VS Code Marketplace
+        run: npx vsce publish -p "$VSCE_PAT"
         env:
-          DISPLAY: ':99.0'
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,15 @@
-name: Build and Publish
+name: Tests
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
 
 jobs:
-  publish:
+  test:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v3
 
@@ -19,10 +22,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build extension
-        run: npm run build
+      - name: Install VS Code
+        run: |
+          curl -L "https://update.code.visualstudio.com/latest/linux-x64/stable" -o vscode.tar.gz
+          tar -xf vscode.tar.gz
 
-      - name: Publish to VS Code Marketplace
-        run: npx vsce publish -p "$VSCE_PAT"
+      - name: Run tests
+        run: xvfb-run -a npm test
         env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          DISPLAY: ':99.0'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,3 @@
-# Add this to your existing ci.yml file
-
 name: CI
 
 on:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,6 @@ name: CI
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 jobs:
   build:
@@ -21,16 +19,11 @@ jobs:
         with:
           node-version: '20.16.0'
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Test ## It's good to double check the tests are passing before publishing
-        run: npm run test
-
       # Only run publish step when pushing to main (not on PRs)
       - name: Publish to VS Code Marketplace
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
+          npm ci
           # Extract version from package.json to use in the vsix filename
           VERSION=$(node -p "require('./package.json').version")
           npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+# Add this to your existing ci.yml file
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      VSCE_PAT: ${{ secrets.VSCE_PAT }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.16.0'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test ## It's good to double check the tests are passing before publishing
+        run: npm run test
+
+      # Only run publish step when pushing to main (not on PRs)
+      - name: Publish to VS Code Marketplace
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          # Extract version from package.json to use in the vsix filename
+          VERSION=$(node -p "require('./package.json').version")
+          npm run build
+          npx vsce publish -p ${{ secrets.VSCE_PAT }}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "test": "vscode-test --extensionDevelopmentPath=. --extensionTestsPath=out/test/extension.test.js",
     "pretest": "npm run compile-tests",
     "posttest": "npm run lint",
-    "build": "npx vsce package"
+    "build": "npx vsce package",
+    "publish": "npx vsce publish"
   },
   "devDependencies": {
     "@types/chai": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "OceanProtocol",
   "displayName": "Ocean Protocol",
   "description": "Easily publish assets and test your algorithms with the official Ocean Protocol vscode extension.",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "engines": {
     "vscode": "^1.96.0"
   },


### PR DESCRIPTION
Fixes #48 

Changes proposed in this PR:

- Updating CI to publish the extension when a new branch is merged into main.