### PR TITLE
logs folder and show errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ocean-protocol-vscode-extension",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ocean-protocol-vscode-extension",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^16.0.0",
         "@chainsafe/libp2p-yamux": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "OceanProtocol",
   "displayName": "Ocean Nodes VS Code Extension",
   "description": "Easily publish assets and test your algorithms with the official Ocean Protocol vscode extension.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "engines": {
     "vscode": "^1.96.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -275,7 +275,12 @@ export async function activate(context: vscode.ExtensionContext) {
                 status.statusText.toLowerCase().includes('error') ||
                 status.statusText.toLowerCase().includes('failed')
               ) {
-                // Reset job state and notify webview on failure
+                try {
+                  await handleFailureLogsRetrieval(config, jobId, status, resultsFolderPath, computeLogsChannel, progress)
+                } catch (retrievalError) {
+                  console.error('Error retrieving logs on failure:', retrievalError)
+                }
+
                 savedJobId = null
                 provider.sendMessage({ type: 'jobStopped' })
                 throw new Error(`Job failed with status: ${status.statusText}`)
@@ -290,15 +295,16 @@ export async function activate(context: vscode.ExtensionContext) {
                   const archive = status.results.find(result => result.filename.includes('.tar'))
                   const resultsWithoutArchive = status.results.filter(result => result.index !== archive?.index)
 
+                  computeLogsChannel.clear()
                   for (const result of resultsWithoutArchive) {
                     progress.report({ message: `Retrieving compute results (${result.index + 1}/${resultsLength})...` })
                     outputChannel.appendLine(`Retrieving compute results (${result.index + 1}/${resultsLength})...`)
                     const filePathLogs = await getAndSaveLogs(config, jobId, result.index, result.filename, resultsFolderPath, progress)
 
-                    // Open log files in editor
-                    const uri = vscode.Uri.file(filePathLogs)
-                    const document = await vscode.workspace.openTextDocument(uri)
-                    await vscode.window.showTextDocument(document, { preview: false })
+                    if (result.filename.toLowerCase().includes('algorithm')) {
+                      const logContent = await fs.promises.readFile(filePathLogs, 'utf-8')
+                      computeLogsChannel.appendLine(logContent)
+                    }
                   }
 
                   try {
@@ -367,6 +373,33 @@ export function deactivate() {
   outputChannel.appendLine('Ocean Protocol extension is being deactivated')
 }
 
+async function handleFailureLogsRetrieval(
+  config: SelectedConfig,
+  jobId: string,
+  status: any,
+  resultsFolderPath: string,
+  computeLogsChannel: vscode.OutputChannel,
+  progress: vscode.Progress<{ message?: string }>
+) {
+  if (!status.results || status.results.length === 0) return
+
+  computeLogsChannel.appendLine(`Job failed with status: ${status.statusText}\n`)
+  const resultsWithoutArchive = status.results.filter(result => !result.filename.includes('.tar'))
+
+  for (const result of resultsWithoutArchive) {
+    try {
+      const filePathLogs = await getAndSaveLogs(config, jobId, result.index, result.filename, resultsFolderPath, progress)
+
+      const logContent = await fs.promises.readFile(filePathLogs, 'utf-8')
+      computeLogsChannel.appendLine(`\n=== ${result.filename} ===\n${logContent}`)
+    } catch (logError) {
+      console.error('Could not retrieve log:', logError)
+    }
+  }
+
+  computeLogsChannel.show(true)
+}
+
 async function getAndSaveLogs(config: SelectedConfig, jobId: string, index: number, fileName: string, resultsFolderPath: string, progress: vscode.Progress<{ message?: string }>) {
   const imageResult = await withRetrial(
     () => getComputeResult(config, jobId, index),
@@ -374,7 +407,6 @@ async function getAndSaveLogs(config: SelectedConfig, jobId: string, index: numb
   )
 
   progress.report({ message: `Saving ${fileName}...` })
-  outputChannel.appendLine(`Saving ${fileName}...`)
   const filePathLogs = await saveResults(
     imageResult,
     resultsFolderPath,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -381,7 +381,9 @@ async function handleFailureLogsRetrieval(
   computeLogsChannel: vscode.OutputChannel,
   progress: vscode.Progress<{ message?: string }>
 ) {
-  if (status.results?.length < 1) return
+  if (!status.results || status.results.length === 0) {
+    return
+  }
 
   computeLogsChannel.appendLine(`Job failed with status: ${status.statusText}\n`)
   const resultsWithoutArchive = status.results.filter(result => !result.filename.includes('.tar'))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -381,7 +381,7 @@ async function handleFailureLogsRetrieval(
   computeLogsChannel: vscode.OutputChannel,
   progress: vscode.Progress<{ message?: string }>
 ) {
-  if (!status.results || status.results.length === 0) return
+  if (status.results?.length < 1) return
 
   computeLogsChannel.appendLine(`Job failed with status: ${status.statusText}\n`)
   const resultsWithoutArchive = status.results.filter(result => !result.filename.includes('.tar'))

--- a/src/helpers/compute.ts
+++ b/src/helpers/compute.ts
@@ -249,17 +249,16 @@ export async function saveResults(
     const baseDir = destinationFolder || path.join(process.cwd(), 'results')
     const dateStr = new Date().toISOString().slice(0, 16).replace(/[:.]/g, '-')
     const resultsDir = path.join(baseDir, `results-${dateStr}`)
+    const logsDir = path.join(resultsDir, 'logs')
 
-    // Ensure results directory exists
-    if (!fs.existsSync(resultsDir)) {
-      console.log('Creating results directory at:', resultsDir)
-      await fs.promises.mkdir(resultsDir, { recursive: true })
+    // Ensure logs directory exists
+    if (!fs.existsSync(logsDir)) {
+      console.log('Creating logs directory at:', logsDir)
+      await fs.promises.mkdir(logsDir, { recursive: true })
     }
 
     const fileName = `${prefix}.txt`
-    const filePath = path.join(resultsDir, fileName)
-
-    console.log('Saving results to:', filePath)
+    const filePath = path.join(logsDir, fileName)
 
     // Write the file
     await fs.promises.writeFile(filePath, results, 'utf-8')

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -227,7 +227,9 @@ suite('Ocean Protocol Extension Test Suite', () => {
       assert.strictEqual(content, JSON.stringify(mockResults))
 
       const pathParts = filePath.split(path.sep)
-      const dateFolderName = pathParts[pathParts.length - 2]
+      const logsFolderName = pathParts[pathParts.length - 2]
+      const dateFolderName = pathParts[pathParts.length - 3]
+      assert.strictEqual(logsFolderName, 'logs', 'File should be in logs folder')
       assert.ok(dateFolderName.startsWith('results-'), 'File should be in a folder with a date')
 
       await fs.promises.rmdir(mockFolderPath, { recursive: true })


### PR DESCRIPTION
Fixes #127 

Changes proposed in this PR:

- Group all logs under a new folder '/logs'
- Do not open the results in editor. The number of logs and results will keep growing so instead we just display them in output channel
- If fails before running algo, show logs in console
<img width="1623" height="1168" alt="Screenshot 2025-10-03 at 09 55 25" src="https://github.com/user-attachments/assets/72fbae52-07b3-4f72-afc6-c7d41b781a97" />
<img width="1623" height="1168" alt="Screenshot 2025-10-03 at 09 56 20" src="https://github.com/user-attachments/assets/54397040-74b0-43c3-bd2b-b1e8be458379" />

